### PR TITLE
[Portal 1.17.0-alpha1] Update default theme for release 1.17.0-alpha1

### DIFF
--- a/src/views/portal_product_detail.tmpl
+++ b/src/views/portal_product_detail.tmpl
@@ -321,11 +321,11 @@
 						{{ if or $oasfile $oasurl $isGraphql }}
 							{{$url := ""}}
 							{{if $oasfile }}
-								{{$url = .OASDocument.Base.Url}}
+								{{$url = .OASDocument.URL}}
 							{{else if $oasurl}}
 								{{$url = .OASUrl}}
 							{{else if $graphqlsdl}}
-								{{$url = .GraphQLSDL.Base.Url}}
+								{{$url = .GraphQLSDL.URL}}
 							{{end}}
 							{{$template := ProductDocTemplate req $thisProduct.Path $spec_detail.SpecAlias }}
 							{{if (eq $initialAPIID "")}}
@@ -349,11 +349,11 @@
 							{{ if or $oasfile $oasurl $graphqlsdl $isGraphQL }}
 								{{$url := ""}}
 								{{if $oasfile }}
-									{{$url = .OASDocument.Base.Url}}
+									{{$url = .OASDocument.URL}}
 								{{else if $oasurl}}
 									{{$url = .OASUrl}}
 								{{else if $graphqlsdl}}
-									{{$url = .GraphQLSDL.Base.Url}}
+									{{$url = .GraphQLSDL.URL}}
 								{{end}}
 								{{$template := ProductDocTemplate req $thisProduct.Path $api_detail.APIID }}
 								{{if and (not $isGraphQL) (eq $initialAPIID "")}}


### PR DESCRIPTION
Automatically synced Portal default theme from Portal release.

**Portal Version**: v1.17.0-alpha1
**Release Version**: 1.17.0-alpha1
**Triggered by**: sedkis
**Release**: https://github.com/TykTechnologies/portal/releases/tag/v1.17.0-alpha1

**Changes**:
- Synced all files from `portal/themes/default/*` to `src/`