### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/create-zip.yml
+++ b/.github/workflows/create-zip.yml
@@ -11,6 +11,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Generate GitHub App token
+      id: app-token
+      uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+      with:
+        app-id: ${{ secrets.PROBE_APP_ID }}
+        private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+        owner: TykTechnologies
+
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Create SRC ZIP
@@ -22,7 +30,7 @@ jobs:
     - name: Upload Release Asset
       uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
       env:
-        GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+        GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ./portal-default-theme-v${{ github.ref_name }}.zip


### PR DESCRIPTION
## Summary
- Replace `secrets.ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) in `create-zip.yml`
- Added app-token generation step to the `build` job

## Test plan
- [ ] Verify create-zip workflow can upload release assets with the app token

🤖 Generated with [Claude Code](https://claude.com/claude-code)